### PR TITLE
Call set_only_v6 method

### DIFF
--- a/src/bin/vpn-client.rs
+++ b/src/bin/vpn-client.rs
@@ -97,6 +97,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::DGRAM, None)?;
     let address: std::net::SocketAddr = "[::]:0".parse().unwrap();
     let address = address.into();
+    socket.set_only_v6(true).unwrap();
     socket.bind(&address)?;
     socket.set_recv_buffer_size(0x7fffffff).unwrap();
     socket.set_nonblocking(true).unwrap();

--- a/src/bin/vpn-server.rs
+++ b/src/bin/vpn-server.rs
@@ -259,6 +259,7 @@ async fn tokio_main(
     let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::DGRAM, None)?;
     let address: std::net::SocketAddr = "[::]:3456".parse().unwrap();
     let address = address.into();
+    socket.set_only_v6(true).unwrap();
     socket.bind(&address)?;
     socket.set_recv_buffer_size(0x7fffffff).unwrap();
     socket.set_nonblocking(true).unwrap();


### PR DESCRIPTION
Call set_only_v6 method to work in the environment where only_v6 is off.